### PR TITLE
Add support for typed variations and updated experiment key FF-852 (#9)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,36 @@
+name: Run Tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Validate composer.json and composer.lock
+      run: composer validate --strict
+
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v3
+      with:
+        path: vendor
+        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php-
+
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress
+
+    - name: Run tests
+      run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+# Make settings - @see https://tech.davis-hansson.com/p/make/
+SHELL := bash
+.ONESHELL:
+.SHELLFLAGS := -eu -o pipefail -c
+.DELETE_ON_ERROR:
+MAKEFLAGS += --warn-undefined-variables
+MAKEFLAGS += --no-builtin-rules
+
+# Log levels
+DEBUG := $(shell printf "\e[2D\e[35m")
+INFO  := $(shell printf "\e[2D\e[36m🔵 ")
+OK    := $(shell printf "\e[2D\e[32m🟢 ")
+WARN  := $(shell printf "\e[2D\e[33m🟡 ")
+ERROR := $(shell printf "\e[2D\e[31m🔴 ")
+END   := $(shell printf "\e[0m")
+
+
+.PHONY: default
+default: help
+
+## help - Print help message.
+.PHONY: help
+help: Makefile
+	@echo "usage: make <target>"
+	@sed -n 's/^##//p' $<
+
+.PHONY: build
+
+## test-data
+testDataDir := tests/data/
+tempDir := ${testDataDir}temp/
+gitDataDir := ${tempDir}sdk-test-data/
+branchName := main
+githubRepoLink := https://github.com/Eppo-exp/sdk-test-data.git
+.PHONY: test-data
+test-data: 
+	rm -rf $(testDataDir)
+	mkdir -p $(tempDir)
+	git clone -b ${branchName} --depth 1 --single-branch ${githubRepoLink} ${gitDataDir}
+	cp ${gitDataDir}rac-experiments-v3.json ${testDataDir}
+	cp -r ${gitDataDir}assignment-v2 ${testDataDir}
+	rm -rf ${tempDir}
+
+.PHONY: test
+test: test-data
+	./vendor/phpunit/phpunit/phpunit tests/EppoClientTest.php

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     }
   ],
   "minimum-stability": "stable",
-  "version": "1.1.0",
   "autoload": {
     "psr-4": {
       "Eppo\\": "src/"

--- a/composer.lock
+++ b/composer.lock
@@ -4,26 +4,26 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a8fa2a1c68958367fd1e4786958003fb",
+    "content-hash": "336bfc592360903bb751eaf8d23816fa",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.5.0",
+            "version": "7.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b50a2a1251152e43f6a37f0fa053e730a67d25ba"
+                "reference": "8444a2bacf1960bc6a2b62ed86b8e72e11eebe51"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b50a2a1251152e43f6a37f0fa053e730a67d25ba",
-                "reference": "b50a2a1251152e43f6a37f0fa053e730a67d25ba",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/8444a2bacf1960bc6a2b62ed86b8e72e11eebe51",
+                "reference": "8444a2bacf1960bc6a2b62ed86b8e72e11eebe51",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "guzzlehttp/promises": "^1.5",
-                "guzzlehttp/psr7": "^1.9 || ^2.4",
+                "guzzlehttp/psr7": "^1.9.1 || ^2.4.5",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.2 || ^3.0"
@@ -48,9 +48,6 @@
                 "bamarni-bin": {
                     "bin-links": true,
                     "forward-command": false
-                },
-                "branch-alias": {
-                    "dev-master": "7.5-dev"
                 }
             },
             "autoload": {
@@ -116,7 +113,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.5.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.6.1"
             },
             "funding": [
                 {
@@ -132,7 +129,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-28T15:39:27+00:00"
+            "time": "2023-05-15T20:43:01+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -3105,5 +3102,5 @@
         "ext-posix": "*",
         "ext-pcntl": "*"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -119,7 +119,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-15T20:43:01+00:00"
+            "time": "2022-06-20T22:16:07+00:00"
         },
         {
             "name": "guzzlehttp/promises",

--- a/src/DTO/ExperimentConfiguration.php
+++ b/src/DTO/ExperimentConfiguration.php
@@ -17,6 +17,9 @@ class ExperimentConfiguration
     private $overrides = [];
 
     /** @var array */
+    private $typedOverrides = [];
+
+    /** @var array */
     private $allocations = [];
 
     /** @var array */
@@ -58,6 +61,7 @@ class ExperimentConfiguration
                 $variation->shardRange = new ShardRange();
                 $variation->name = $configVariation['name'];
                 $variation->value = $configVariation['value'];
+                $variation->typedValue = $configVariation['typedValue'];
                 $variation->shardRange->start = $configVariation['shardRange']['start'];
                 $variation->shardRange->end = $configVariation['shardRange']['end'];
 
@@ -68,7 +72,8 @@ class ExperimentConfiguration
         }
         $this->setAllocations($allocations);
 
-        $this->setOverrides($configuration['overrides']);
+        $this->setOverrides($configuration['overrides'] ?? []);
+        $this->setTypedOverrides($configuration['typedOverrides'] ?? []);
     }
 
     /**
@@ -133,6 +138,22 @@ class ExperimentConfiguration
     public function setOverrides(array $overrides): void
     {
         $this->overrides = $overrides;
+    }
+
+    /**
+     * @return array
+     */
+    public function getTypedOverrides(): array
+    {
+        return $this->typedOverrides;
+    }
+
+    /**
+     * @param array $overrides
+     */
+    public function setTypedOverrides(array $typedOverrides): void
+    {
+        $this->typedOverrides = $typedOverrides;
     }
 
     /**

--- a/src/DTO/Variation.php
+++ b/src/DTO/Variation.php
@@ -10,6 +10,9 @@ class Variation
     /** @var string */
     public $value;
 
+    /** @var mixed */
+    public $typedValue;
+
     /** @var ShardRange */
     public $shardRange;
 }

--- a/src/Logger/LoggerInterface.php
+++ b/src/Logger/LoggerInterface.php
@@ -5,23 +5,17 @@ namespace Eppo\Logger;
 interface LoggerInterface
 {
     /**
-     * Method used by EppoClient to log assignments.
-     * Will pass to this method all the assignment information, and, based on implementation,
+     * Method used by EppoClient to log assignments to the data warehouse.
+     * This method will be passed all the assignment information, and, based on implementation,
      * try to log this information.
-     *
-     * @param string $experiment
-     * @param string $variation
-     * @param string $subject
-     * @param string $timestamp
-     * @param array $subjectAttributes
-     *
-     * @return void
      */
     public function logAssignment(
         string $experiment,
         string $variation,
         string $subject,
         string $timestamp,
-        array $subjectAttributes = []
+        array $subjectAttributes = [],
+        ?string $allocation = null,
+        ?string $featureFlag = null
     ): void;
 }

--- a/tests/EppoClientTest.php
+++ b/tests/EppoClientTest.php
@@ -29,6 +29,7 @@ class EppoClientTest extends TestCase
         'enabled' => true,
         'subjectShards' => 100,
         'overrides' => [],
+        'typedOverrides' => [],
         'rules' => [
             [
                 'allocationKey' => 'allocation1',
@@ -42,6 +43,7 @@ class EppoClientTest extends TestCase
                     [
                         'name' => 'control',
                         'value' => 'control',
+                        'typedValue' => 'control',
                         'shardRange' => [
                             'start' => 0,
                             'end' => 34,
@@ -50,6 +52,7 @@ class EppoClientTest extends TestCase
                     [
                         'name' => 'variant-1',
                         'value' => 'variant-1',
+                        'typedValue' => 'variant-1',
                         'shardRange' => [
                             'start' => 34,
                             'end' => 67,
@@ -58,6 +61,7 @@ class EppoClientTest extends TestCase
                     [
                         'name' => 'variant-2',
                         'value' => 'variant-2',
+                        'typedValue' => 'variant-2',
                         'shardRange' => [
                             'start' => 67,
                             'end' => 100,
@@ -96,26 +100,43 @@ class EppoClientTest extends TestCase
 
     public function testGetAssignmentVariationAssignmentSplits(): void
     {
+        $client = EppoClient::getInstance();
         $assignmentsTestData = self::$testFilesHelper->readAssignmentTestData();
 
         foreach ($assignmentsTestData as $assignmentTestData) {
             $experiment = $assignmentTestData['experiment'];
-            $subjects = array_key_exists('subjects', $assignmentTestData)
-                ? $assignmentTestData['subjects']
-                : null;
-            $subjectsWithAttributes = array_key_exists('subjectsWithAttributes', $assignmentTestData)
-                ? $assignmentTestData['subjectsWithAttributes']
-                : null;
+            
+            // Some test case have only subject keys, others have keys and attributes. Either way we'll, put them into a
+            // single array with the subject keys to attributes (if any) 
+            $subjectsWithAttributes = $assignmentTestData['subjectsWithAttributes'] ?? [];
+            foreach($assignmentTestData["subjects"] ?? [] as $subjectKey) {
+                $subjectsWithAttributes[] = ["subjectKey" => $subjectKey, "subjectAttributes" => []];
+            }
+
+            // Use the hint from the test to determine what typed assignment function we should use
+            $testValueType = $assignmentTestData["valueType"];
+
+            // For each subject, retrieve the typed assignment
+            $assignments = array_map(function($subjectWithAttributes) use ($client, $testValueType, $experiment) {
+                
+                $subjectKey = $subjectWithAttributes["subjectKey"];
+                $subjectAttributes = $subjectWithAttributes["subjectAttributes"];
+
+                switch ($testValueType) {
+                    case EppoClient::VARIANT_TYPE_STRING:
+                        return $client->getStringAssignment($subjectKey, $experiment, $subjectAttributes);
+                    case EppoClient::VARIANT_TYPE_NUMERIC:
+                        return $client->getNumericAssignment($subjectKey, $experiment, $subjectAttributes);
+                    case EppoClient::VARIANT_TYPE_BOOLEAN:
+                        return $client->getBooleanAssignment($subjectKey, $experiment, $subjectAttributes);
+                    case EppoClient::VARIANT_TYPE_JSON:
+                        return $client->getJSONStringAssignment($subjectKey, $experiment, $subjectAttributes);
+                    default:
+                        throw new InvalidArgumentException("Unexpected test value type $testValueType");
+                }   
+            }, $subjectsWithAttributes);
 
             $expectedAssignments = $assignmentTestData['expectedAssignments'];
-
-            try {
-                $assignments = !!$subjectsWithAttributes
-                    ? $this->getAssignmentsWithSubjectAttributes($subjectsWithAttributes, $experiment)
-                    : $this->getAssignments($subjects, $experiment);
-            } catch (Exception|GuzzleException|\Psr\SimpleCache\InvalidArgumentException $exception) {
-                $this->fail('Test failed: ' . $exception->getMessage());
-            }
 
             $this->assertEquals($expectedAssignments, $assignments);
         }
@@ -180,6 +201,7 @@ class EppoClientTest extends TestCase
                     [
                         'name' => 'control',
                         'value' => 'control',
+                        'typedValue' => 'control',
                         'shardRange' => [
                             'start' => 0,
                             'end' => 50
@@ -188,6 +210,7 @@ class EppoClientTest extends TestCase
                     [
                         'name' => 'treatment',
                         'value' => 'treatment',
+                        'typedValue' => 'treatment',
                         'shardRange' => [
                             'start' => 50,
                             'end' => 100
@@ -234,7 +257,7 @@ class EppoClientTest extends TestCase
         $mockLogger = $this->getLoggerMock();
         $mockLogger->expects($this->once())
             ->method('logAssignment')
-            ->with('mock-experiment', 'control', 'subject-10')
+            ->with('mock-experiment-allocation1', 'control', 'subject-10')
             ->willThrowException(new Exception('logger error'));
         $subjectAttributes = [['foo' => 3]];
 
@@ -242,48 +265,6 @@ class EppoClientTest extends TestCase
         $assignment = $client->getAssignment('subject-10', self::EXPERIMENT_NAME, $subjectAttributes);
 
         $this->assertEquals('control', $assignment);
-    }
-
-    /**
-     * @param array $subjects
-     * @param string $experiment
-     * @return array
-     * @throws HttpRequestException
-     * @throws InvalidApiKeyException
-     * @throws InvalidArgumentException
-     * @throws GuzzleException
-     * @throws \Psr\SimpleCache\InvalidArgumentException
-     */
-    private function getAssignments(array $subjects, string $experiment): array
-    {
-        $client = EppoClient::getInstance();
-        $assignments = [];
-        foreach ($subjects as $subjectKey) {
-            $assignments[] = $client->getAssignment($subjectKey, $experiment);
-        }
-
-        return $assignments;
-    }
-
-    /**
-     * @param array $subjectsWithAttributes
-     * @param string $experiment
-     * @return array
-     * @throws GuzzleException
-     * @throws HttpRequestException
-     * @throws InvalidApiKeyException
-     * @throws InvalidArgumentException
-     * @throws \Psr\SimpleCache\InvalidArgumentException
-     */
-    private function getAssignmentsWithSubjectAttributes(array $subjectsWithAttributes, string $experiment): array
-    {
-        $client = EppoClient::getInstance();
-        $assignments = [];
-        foreach ($subjectsWithAttributes as $subject) {
-            $assignment = $client->getAssignment($subject['subjectKey'], $experiment, $subject['subjectAttributes']);
-            $assignments[] = $assignment;
-        }
-        return $assignments;
     }
 
     /**
@@ -321,8 +302,16 @@ class EppoClientTest extends TestCase
     private function getLoggerMock()
     {
         $mockLogger = $this->getMockBuilder(LoggerInterface::class)->getMock();
-        $mockLogger->expects($this->once())->method('logAssignment')->with('mock-experiment', 'control', 'subject-10');
+        $mockLogger->expects($this->once())->method('logAssignment')->with(
+            'mock-experiment-allocation1', 
+            'control', 
+            'subject-10',
+            $this->greaterThan(0),
+            $this->anything(),
+            'allocation1',
+            'mock-experiment'
+        );
 
-        return $mockLogger;
+        return $mockLogger; 
     }
 }

--- a/tests/WebServer/router.php
+++ b/tests/WebServer/router.php
@@ -3,7 +3,7 @@
 header('Content-Type: application/json');
 
 if (strpos($_SERVER["REQUEST_URI"], '/randomized_assignment/v3/config') !== false) {
-    echo file_get_contents(__DIR__ . '/../data/rac-experiments-v2.json');
+    echo file_get_contents(__DIR__ . '/../data/rac-experiments-v3.json');
     return;
 } else {
     return 'Not Found';


### PR DESCRIPTION
Cherry pick dynamic configuration change (https://github.com/Eppo-exp/php-sdk/commit/3d2d4c77d864a4c7e0040b8eee321bc5dba68502) from upstream into this fork.